### PR TITLE
Add Himalayas as a remote job board

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 - [Basecamp Jobs](https://basecamp.com/jobs) - Basecamp is well know for having a successful remote team.
 - [FreshRemote.work](https://freshremote.work/)
 - [GitHub jobs](https://jobs.github.com/positions?description=&location=remote) - They have a remote option to filter.
+- [Himalayas](https://himalayas.app)
 - [Jobscribe](https://jobscribe.co.nz)
 - [DailyRemote](https://dailyremote.com)
 - [Jobspresso](https://jobspresso.co/)


### PR DESCRIPTION
Added https://himalayas.app/ as a remote job board resource.

Himalayas is a remote job board that offers a large range of remote-specific filters, jobs, and company profiles, including information about company tech stacks and benefits. It is free for job seekers to use to find remote jobs.